### PR TITLE
Use Python 3.11 slim image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   data_processor:
-    image: python:latest
+    image: python:3.11-slim
     volumes:
       - ./prediction_log:/data
       - ./src:/src


### PR DESCRIPTION
## Summary
- target Python 3.11-slim container in compose file

## Testing
- `python -m venv .venv && source .venv/bin/activate && pip install -r src/requirements.txt` *(failed: Could not find a version that satisfies the requirement certifi==2025.7.9)*

------
https://chatgpt.com/codex/tasks/task_b_68931c616be083219dcaca8fb3167f53